### PR TITLE
Enable WebView debugging

### DIFF
--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -19,6 +19,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        WebView.setWebContentsDebuggingEnabled(true)
 
         supportFragmentManager.beginTransaction()
             .replace(R.id.container, ViewPagerFragment())


### PR DESCRIPTION
Hi, ymnder.

https://developers.google.com/web/tools/chrome-devtools/remote-debugging/webviews
>WebView debugging must be enabled from within your application. To enable WebView debugging, call the static method setWebContentsDebuggingEnabled on the WebView class.

Thanks.